### PR TITLE
Add binary to expose URL a bit easier...

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ Retrieve a URL that can be used to reference a tarball representing the latest
 
 ## Usage
 
+### Command Line API
+
+```js
+npm install -g ember-source-channel-url
+ember-source-channel-url canary
+```
+
+Will print out:
+
+```sh
+The URL for the latest tarball from ember-source's canary channel is:
+
+        https://s3.amazonaws.com/builds.emberjs.com/canary/shas/<RANDOM SHA HERE>.tgz
+```
+### Progamatic API
 ```js
 const getURLFor = require('ember-source-channel-url');
 

--- a/bin/ember-source-channel-url
+++ b/bin/ember-source-channel-url
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+'use strict';
+
+/* eslint-disable no-console */
+
+const getChannelURL = require('../src');
+const channel = process.argv[2];
+
+if (['release', 'beta', 'canary'].indexOf(channel) === -1) {
+  console.log(
+    `ember-source-channel-url is a utility module to easily obtain the URL
+to a tarball representing the latest \`ember-source\` build for a given
+channel.
+
+Usage:
+
+  ember-source-channel-url canary
+  ember-source-channel-url beta
+  ember-source-channel-url release
+`
+  );
+} else {
+  getChannelURL(channel).then(url =>
+    console.log(
+      `The URL for the latest tarball from ember-source's ${channel} channel is:\n\n\t${url}`
+    )
+  );
+}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "license": "MIT",
   "author": "Robert Jackson <me@rwjblue.com>",
   "files": [
+    "bin/",
     "src/"
   ],
   "main": "src/index.js",
+  "bin": "./bin/ember-source-channel-url",
   "repository": "git@github.com:rwjblue/ember-source-channel-url.git",
   "scripts": {
     "test": "qunit tests/**/*-test.js"
@@ -20,6 +22,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-prettier": "^2.4.0",
+    "execa": "^0.10.0",
     "get-port": "^3.2.0",
     "prettier": "^1.10.2",
     "qunit": "^2.5.0",

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const path = require('path');
 const crypto = require('crypto');
+const execa = require('execa');
 const createServer = require('./helpers/server').createServer;
 const getChannelURL = require('../src');
 
@@ -36,6 +38,19 @@ QUnit.module('ember-source-channel-url', function(hooks) {
 
     return getChannelURL('canary').then(actual => {
       assert.equal(actual, expected);
+    });
+  });
+
+  QUnit.module('binary', function() {
+    QUnit.test('works', function(assert) {
+      let expected = `http://${this.server.host}:${this.server.port}/builds.emberjs.com${
+        this.assetPath
+      }`;
+
+      let executablePath = path.join(__dirname, '..', 'bin', 'ember-source-channel-url');
+      return execa(executablePath, ['canary']).then(results => {
+        assert.ok(results.stdout.includes(expected), 'URL is present in stdout');
+      });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -420,6 +420,16 @@ cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^6.0.0:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -632,6 +642,18 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
+execa@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 exists-stat@1.0.0:
   version "1.0.0"
@@ -1288,6 +1310,10 @@ is-retry-allowed@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -1570,6 +1596,10 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
 node-pre-gyp@^0.6.39:
   version "0.6.39"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
@@ -1606,6 +1636,12 @@ normalize-url@2.0.1:
     prepend-http "^2.0.0"
     query-string "^5.0.1"
     sort-keys "^2.0.0"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
 
 npmlog@^4.0.2:
   version "4.1.2"
@@ -1735,6 +1771,10 @@ path-is-absolute@^1.0.0:
 path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^2.0.0, path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -2001,6 +2041,10 @@ semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
+semver@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
 set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -2185,6 +2229,10 @@ strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
```sh
npm install -g ember-source-channel-url
ember-source-channel-url canary
```

Will emit:

```
The URL for the latest tarball from ember-source's canary channel is:

        https://s3.amazonaws.com/builds.emberjs.com/canary/shas/<RANDOM SHA HERE>.tgz
```