### PR TITLE
Ensure any trailing whitespace in package.json is preserved.

### DIFF
--- a/bin/ember-source-channel-url
+++ b/bin/ember-source-channel-url
@@ -7,6 +7,7 @@ const fs = require('fs');
 const getChannelURL = require('../src');
 const channel = process.argv[2];
 const shouldUpdatePackage = process.argv.includes('-w') || process.argv.includes('--write');
+const DETECT_TRAILING_WHITESPACE = /\s+$/;
 
 function printUsage() {
   console.log(`
@@ -55,6 +56,7 @@ if (['release', 'beta', 'canary'].indexOf(channel) === -1) {
       }
 
       let contents = fs.readFileSync('package.json', { encoding: 'utf8' });
+      let trailingWhitespace = DETECT_TRAILING_WHITESPACE.exec(contents);
       let pkg = JSON.parse(contents);
 
       let dependencyType = ['dependencies', 'devDependencies'].find(
@@ -65,6 +67,11 @@ if (['release', 'beta', 'canary'].indexOf(channel) === -1) {
         pkg[dependencyType]['ember-source'] = url;
 
         let updatedContents = JSON.stringify(pkg, null, 2);
+
+        if (trailingWhitespace) {
+          updatedContents += trailingWhitespace[0];
+        }
+
         fs.writeFileSync('package.json', updatedContents, { encoding: 'utf8' });
       } else {
         console.log(

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -120,6 +120,22 @@ QUnit.module('ember-source-channel-url', function(hooks) {
       });
     });
 
+    QUnit.test('preserves line ending when updating package.json', function(assert) {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({ dependencies: { 'ember-source': '^3.10.0' } }, null, 2) + '\n',
+        { encoding: 'utf8' }
+      );
+
+      return execa(EXECUTABLE_PATH, ['canary', '--write']).then(results => {
+        assert.ok(results.stdout.includes(this.expectedURL), 'URL is present in stdout');
+
+        let expected =
+          JSON.stringify({ dependencies: { 'ember-source': this.expectedURL } }, null, 2) + '\n';
+        assert.deepEqual(fs.readFileSync('package.json', { encoding: 'utf8' }), expected);
+      });
+    });
+
     QUnit.test('fails when package.json is missing', function(assert) {
       return execa(EXECUTABLE_PATH, ['canary', '--write']).catch(results => {
         assert.ok(results.stdout.includes(this.expectedURL), 'URL is present in stdout');


### PR DESCRIPTION
When testing the new `--write` functionality I noticed that my `package.json` had changed trailing whitespace as well as the `ember-source` URL. That was annoying.