### PR TITLE
Print only the url when being piped/scripted.

### DIFF
--- a/bin/ember-source-channel-url
+++ b/bin/ember-source-channel-url
@@ -42,9 +42,13 @@ if (['release', 'beta', 'canary'].indexOf(channel) === -1) {
   process.exitCode = 1;
 } else {
   getChannelURL(channel).then(url => {
-    console.log(
-      `The URL for the latest tarball from ember-source's ${channel} channel is:\n\n\t${url}\n`
-    );
+    if (process.stdout.isTTY) {
+      console.log(
+        `The URL for the latest tarball from ember-source's ${channel} channel is:\n\n\t${url}\n`
+      );
+    } else {
+      process.stdout.write(url);
+    }
 
     if (shouldUpdatePackage) {
       if (!fs.existsSync('package.json')) {

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -62,6 +62,17 @@ QUnit.module('ember-source-channel-url', function(hooks) {
       });
     });
 
+    QUnit.test('when the terminal is not a TTY return only the URL', function(assert) {
+      let file = tmp.fileSync();
+      return execa(EXECUTABLE_PATH, ['canary'], { stdout: file.fd }).then(() => {
+        assert.equal(
+          fs.readFileSync(file.name, { encoding: 'utf8' }),
+          this.expectedURL,
+          'stdout is the URL'
+        );
+      });
+    });
+
     QUnit.test('updates local package.json when -w is passed (dependencies)', function(assert) {
       fs.writeFileSync(
         'package.json',


### PR DESCRIPTION
This ensures that something akin to `ember-source-channel-url > some-file.txt` writes only the URL (not the verbose console message).